### PR TITLE
Provision through jumpbox host

### DIFF
--- a/catalog/main.tf
+++ b/catalog/main.tf
@@ -73,6 +73,7 @@ module "web" {
 
   ami_id           = "${data.aws_ami.ubuntu.id}"
   ansible_group    = "catalog_web"
+  bastion_host     = "${data.terraform_remote_state.jumpbox.jumpbox_dns}"
   dns_zone_public  = "${data.terraform_remote_state.vpc.dns_zone_public}"
   dns_zone_private = "${data.terraform_remote_state.vpc.dns_zone_private}"
   env              = "${var.env}"

--- a/crm/main.tf
+++ b/crm/main.tf
@@ -63,6 +63,7 @@ module "web" {
 
   ami_id           = "${data.aws_ami.ubuntu.id}"
   ansible_group    = "crm_web"
+  bastion_host     = "${data.terraform_remote_state.jumpbox.jumpbox_dns}"
   dns_zone_public  = "${data.terraform_remote_state.vpc.dns_zone_public}"
   dns_zone_private = "${data.terraform_remote_state.vpc.dns_zone_private}"
   env              = "${var.env}"

--- a/dashboard/main.tf
+++ b/dashboard/main.tf
@@ -63,6 +63,7 @@ module "web" {
 
   ami_id           = "${data.aws_ami.ubuntu.id}"
   ansible_group    = "dashboard_web"
+  bastion_host     = "${data.terraform_remote_state.jumpbox.jumpbox_dns}"
   dns_zone_public  = "${data.terraform_remote_state.vpc.dns_zone_public}"
   dns_zone_private = "${data.terraform_remote_state.vpc.dns_zone_private}"
   env              = "${var.env}"

--- a/inventory/main.tf
+++ b/inventory/main.tf
@@ -73,6 +73,7 @@ module "web" {
 
   ami_id           = "${data.aws_ami.ubuntu.id}"
   ansible_group    = "inventory_web"
+  bastion_host     = "${data.terraform_remote_state.jumpbox.jumpbox_dns}"
   dns_zone_public  = "${data.terraform_remote_state.vpc.dns_zone_public}"
   dns_zone_private = "${data.terraform_remote_state.vpc.dns_zone_private}"
   env              = "${var.env}"

--- a/jumpbox/main.tf
+++ b/jumpbox/main.tf
@@ -145,8 +145,8 @@ resource "aws_instance" "jumpbox" {
   }
 
   connection {
-    type     = "ssh"
-    user     = "ubuntu"
+    type = "ssh"
+    user = "ubuntu"
   }
 
   provisioner "remote-exec" {

--- a/modules/stateful/bin/initialize-stateful.sh
+++ b/modules/stateful/bin/initialize-stateful.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -x
+
+disk="${1:-/dev/xvdh}"
+partition="${disk}1"
+
+if [[ -b "$partition" ]]; then
+  # disk is already initialized, nothing to do
+  exit 0
+fi
+
+# write the partition table with a single partition taking the full disk
+parted --script --align optimal "$disk" -- mklabel gpt mkpart primary ext4 1M -1M name 1 data
+
+# sync the disk, just in case
+sync
+
+# format the partition
+mkfs -t ext4 "$partition"
+
+# mount the partition at boot
+echo "$partition   /data        ext4   defaults,discard        0 1" >> /etc/fstab
+
+# mount the partition now
+mkdir /data
+mount "$partition" /data

--- a/modules/stateful/variables.tf
+++ b/modules/stateful/variables.tf
@@ -7,6 +7,11 @@ variable "availability_zones" {
   description = "List of availability zones to create EBS volumes in."
 }
 
+variable "bastion_host" {
+  description = "Host/ip for the jumpbox/bastion host to connect to for provisioning."
+  default     = ""                                                                     # unset
+}
+
 variable "dns_zone" {
   description = "DNS zone to create hostname records."
 }

--- a/modules/stateless/main.tf
+++ b/modules/stateless/main.tf
@@ -24,6 +24,21 @@ resource "aws_instance" "default" {
   lifecycle {
     create_before_destroy = true
   }
+
+  provisioner "remote-exec" {
+    connection {
+      type = "ssh"
+      user = "ubuntu"
+
+      bastion_host = "${var.bastion_host != "" ? var.bastion_host : aws_instance.default.private_ip}"
+    }
+
+    # install Ansible executor dependencies
+    inline = [
+      "sudo apt-get update",
+      "sudo apt-get install -y python",
+    ]
+  }
 }
 
 resource "aws_route53_record" "default" {

--- a/modules/stateless/variables.tf
+++ b/modules/stateless/variables.tf
@@ -6,6 +6,11 @@ variable "ansible_group" {
   description = "Name of the ansible group to tag web instances with."
 }
 
+variable "bastion_host" {
+  description = "Host/ip for the jumpbox/bastion host to connect to for provisioning."
+  default     = ""
+}
+
 variable "dns_zone" {
   description = "Internal DNS zone to create host records for."
 }

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -51,6 +51,21 @@ resource "aws_instance" "web" {
   lifecycle {
     create_before_destroy = true
   }
+
+  provisioner "remote-exec" {
+    connection {
+      type = "ssh"
+      user = "ubuntu"
+
+      bastion_host = "${var.bastion_host != "" ? var.bastion_host : aws_instance.default.private_ip}"
+    }
+
+    # install Ansible executor dependencies
+    inline = [
+      "sudo apt-get update",
+      "sudo apt-get install -y python",
+    ]
+  }
 }
 
 resource "aws_lb_target_group_attachment" "lb" {

--- a/modules/web/variables.tf
+++ b/modules/web/variables.tf
@@ -3,6 +3,11 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "bastion_host" {
+  description = "Host/ip for the jumpbox/bastion host to connect to for provisioning."
+  default     = ""
+}
+
 variable "name" {
   description = "Name slug to use as a prefix or name for resources."
   type        = "string"

--- a/solr/main.tf
+++ b/solr/main.tf
@@ -88,6 +88,7 @@ module "solr" {
   ami_id               = "${data.aws_ami.ubuntu.id}"
   ansible_group        = "solr"
   availability_zones   = "${data.terraform_remote_state.vpc.azs}"
+  bastion_host         = "${data.terraform_remote_state.jumpbox.jumpbox_dns}"
   dns_zone             = "${data.terraform_remote_state.vpc.dns_zone_private}"
   ebs_size             = "${var.ebs_size}"
   env                  = "${var.env}"

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -23,6 +23,7 @@ resource "aws_route53_record" "public_zone" {
   name    = "${aws_route53_zone.public.name}"
   type    = "NS"
   ttl     = "300"
+
   records = [
     "${aws_route53_zone.public.name_servers.0}",
     "${aws_route53_zone.public.name_servers.1}",
@@ -36,6 +37,7 @@ resource "aws_route53_record" "private_zone" {
   name    = "${aws_route53_zone.private.name}"
   type    = "NS"
   ttl     = "300"
+
   records = [
     "${aws_route53_zone.private.name_servers.0}",
     "${aws_route53_zone.private.name_servers.1}",

--- a/wordpress/main.tf
+++ b/wordpress/main.tf
@@ -63,6 +63,7 @@ module "web" {
 
   ami_id           = "${data.aws_ami.ubuntu.id}"
   ansible_group    = "wordpress_web"
+  bastion_host     = "${data.terraform_remote_state.jumpbox.jumpbox_dns}"
   dns_zone_public  = "${data.terraform_remote_state.vpc.dns_zone_public}"
   dns_zone_private = "${data.terraform_remote_state.vpc.dns_zone_private}"
   env              = "${var.env}"


### PR DESCRIPTION
For ansible, each host needs python installed. Since hosts are firewalled via security groups, terraform can't just ssh into them to provision, so we use the [bastion_host feature](https://www.terraform.io/docs/provisioners/connection.html#connecting-through-a-bastion-host-with-ssh).

For stateful instances like solr, this also includes initialization of the disk.