### PR TITLE
Bump instance type for catalog

### DIFF
--- a/catalog/main.tf
+++ b/catalog/main.tf
@@ -78,6 +78,7 @@ module "web" {
   dns_zone_private = "${data.terraform_remote_state.vpc.dns_zone_private}"
   env              = "${var.env}"
   instance_count   = "${var.web_instance_count}"
+  instance_type    = "${var.web_instance_type}"
   key_name         = "${var.key_name}"
   name             = "catalog"
   private_subnets  = "${data.terraform_remote_state.vpc.private_subnets}"

--- a/catalog/variables.tf
+++ b/catalog/variables.tf
@@ -22,6 +22,11 @@ variable "web_instance_count" {
   default     = 1
 }
 
+variable "web_instance_type" {
+  description = "Instance type to use for web."
+  default     = "t3.small"
+}
+
 variable "harvester_instance_count" {
   description = "Number of harvester instances to create."
   default     = 1


### PR DESCRIPTION
With all the services started, they run out of memory during a catalog deploy
and hang.