### PR TITLE
Ignore AMI updates on jumpbox

### DIFF
--- a/modules/jumpbox/main.tf
+++ b/modules/jumpbox/main.tf
@@ -131,6 +131,12 @@ resource "aws_instance" "jumpbox" {
     user = "ubuntu"
   }
 
+  lifecycle {
+    ignore_changes = [
+      "ami",
+    ]
+  }
+
   provisioner "remote-exec" {
     script = "${path.module}/bin/provision.sh"
   }


### PR DESCRIPTION
Avoid destroy/recreate for new AMI images.