### PR TITLE
Move egress rules to a "default" security group

### DIFF
--- a/jenkins/main.tf
+++ b/jenkins/main.tf
@@ -51,6 +51,10 @@ data "aws_route53_zone" "public" {
   name = "${data.terraform_remote_state.vpc.dns_zone_public}"
 }
 
+data "aws_security_group" "default" {
+  name = "default-${var.env}"
+}
+
 resource "aws_security_group" "default" {
   name        = "jenkins-${var.env}-tf"
   description = "Jenkins security group"
@@ -64,20 +68,6 @@ resource "aws_security_group" "default" {
   }
 
   ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
@@ -161,7 +151,7 @@ module "jenkins" {
   instance_name_format        = "jenkins%dtf"
   instance_type               = "t2.medium"
   key_name                    = "${var.key_name}"
-  security_groups             = ["${aws_security_group.default.id}", "${data.terraform_remote_state.jumpbox.security_group_id}"]
+  security_groups             = ["${data.aws_security_group.default.id}", "${aws_security_group.default.id}", "${data.terraform_remote_state.jumpbox.security_group_id}"]
   subnets                     = "${data.terraform_remote_state.vpc.public_subnets}"
   vpc_id                      = "${data.terraform_remote_state.vpc.vpc_id}"
 }

--- a/modules/db/rds.tf
+++ b/modules/db/rds.tf
@@ -1,3 +1,7 @@
+data "aws_security_group" "default" {
+  name = "default-${var.env}"
+}
+
 resource "aws_db_instance" "default" {
   allocated_storage      = "${var.db_allocated_storage}"
   storage_type           = "${var.db_storage_type}"
@@ -8,7 +12,7 @@ resource "aws_db_instance" "default" {
   username               = "${var.db_username}"
   password               = "${var.db_password}"
   db_subnet_group_name   = "${var.database_subnet_group}"
-  vpc_security_group_ids = ["${aws_security_group.default.id}"]
+  vpc_security_group_ids = ["${data.aws_security_group.default.id}", "${aws_security_group.default.id}"]
   parameter_group_name   = "${var.db_parameter_group_name}"
   skip_final_snapshot    = "${var.db_skip_final_snapshot}"
   multi_az               = "${var.db_multi_az}"

--- a/modules/db/sg.tf
+++ b/modules/db/sg.tf
@@ -1,12 +1,11 @@
-# postgres security group
 resource "aws_security_group" "default" {
   name        = "${var.db_name}-${var.env}-db-tf"
   description = "Database security group"
   vpc_id      = "${var.vpc_id}"
 
   ingress {
-    from_port       = 5432
-    to_port         = 5432
+    from_port       = "${var.database_port}"
+    to_port         = "${var.database_port}"
     protocol        = "tcp"
     security_groups = ["${aws_security_group.db_access.id}"]
   }
@@ -30,4 +29,11 @@ resource "aws_security_group" "db_access" {
   name        = "${var.db_name}-${var.env}-db-access-tf"
   description = "Allowed access to database"
   vpc_id      = "${var.vpc_id}"
+
+  egress {
+    from_port = "${var.database_port}"
+    to_port = "${var.database_port}"
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/8"]
+  }
 }

--- a/modules/db/sg.tf
+++ b/modules/db/sg.tf
@@ -9,20 +9,6 @@ resource "aws_security_group" "default" {
     protocol        = "tcp"
     security_groups = ["${aws_security_group.db_access.id}"]
   }
-
-  egress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 }
 
 resource "aws_security_group" "db_access" {

--- a/modules/db/vars.tf
+++ b/modules/db/vars.tf
@@ -31,7 +31,10 @@ variable "db_username" {
 }
 
 variable "db_password" {
-  default = "ckanckan"
+}
+
+variable "database_port" {
+  description = "The port used to connect to the database. This will be used to configure security groups."
 }
 
 variable "database_subnet_group" {

--- a/modules/jumpbox/main.tf
+++ b/modules/jumpbox/main.tf
@@ -28,6 +28,10 @@ data "aws_route53_zone" "private" {
   private_zone = true
 }
 
+data "aws_security_group" "default" {
+  name = "default-${var.env}"
+}
+
 resource "aws_security_group" "default" {
   name        = "${var.env}-jumpbox-sg-tf"
   description = "Jumpbox security group"
@@ -45,20 +49,6 @@ resource "aws_security_group" "default" {
     to_port     = 22
     protocol    = "tcp"
     cidr_blocks = ["10.0.0.0/8"]
-  }
-
-  egress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
@@ -128,7 +118,7 @@ resource "aws_iam_instance_profile" "jumpbox" {
 resource "aws_instance" "jumpbox" {
   ami                         = "${data.aws_ami.ubuntu.id}"
   instance_type               = "${var.instance_type}"
-  vpc_security_group_ids      = ["${aws_security_group.default.id}"]
+  vpc_security_group_ids      = ["${data.aws_security_group.default.id}", "${aws_security_group.default.id}"]
   subnet_id                   = "${var.public_subnets[0]}"
   key_name                    = "${var.key_name}"
   iam_instance_profile        = "${aws_iam_instance_profile.jumpbox.name}"

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -13,4 +13,5 @@ module "database" {
   db_username            = "${var.db_username}"
   vpc_id                 = "${var.vpc_id}"
   env                    = "${var.env}"
+  database_port          = 3306
 }

--- a/modules/postgresdb/main.tf
+++ b/modules/postgresdb/main.tf
@@ -13,4 +13,5 @@ module "database" {
   db_username            = "${var.db_username}"
   vpc_id                 = "${var.vpc_id}"
   env                    = "${var.env}"
+  database_port          = 5432
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -51,6 +51,40 @@ resource "aws_route53_zone" "private" {
   }
 }
 
+resource "aws_security_group" "default" {
+  name = "default-${var.env}"
+  description = "Default security group allowing common egress rules for ${var.env}."
+  vpc_id = "${module.vpc.vpc_id}"
+
+  # Allow outbound HTTP access for Ubuntu apt updates
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outbound HTTPS access for Ubuntu apt updates
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outbound NTP access
+  egress {
+    from_port   = 123
+    to_port     = 123
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    env = "${var.env}"
+  }
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "1.67.0"

--- a/modules/web/lb.tf
+++ b/modules/web/lb.tf
@@ -32,20 +32,6 @@ resource "aws_security_group" "lb" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
-  egress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 }
 
 module "lb" {
@@ -58,7 +44,7 @@ module "lb" {
   http_tcp_listeners_count = "${local.lb_http_listeners_count}"
   http_tcp_listeners       = ["${local.lb_http_listeners}"]
   logging_enabled          = false
-  security_groups          = ["${aws_security_group.lb.id}"]
+  security_groups          = ["${data.aws_security_group.default.id}", "${aws_security_group.lb.id}"]
   subnets                  = ["${var.public_subnets}"]
   target_groups_count      = "${length(var.lb_target_groups)}"
   target_groups            = ["${var.lb_target_groups}"]

--- a/solr/main.tf
+++ b/solr/main.tf
@@ -102,6 +102,20 @@ resource "aws_security_group" "solr_access" {
   name        = "solr-access-${var.env}-tf"
   description = "Provides access to solr"
   vpc_id      = "${data.terraform_remote_state.vpc.vpc_id}"
+
+  egress {
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    cidr_blocks = ["10.0.0.0/8"]
+  }
+
+  egress {
+    from_port       = 8983
+    to_port         = 8983
+    protocol        = "tcp"
+    cidr_blocks = ["10.0.0.0/8"]
+  }
 }
 
 module "solr" {


### PR DESCRIPTION
- Fixes some missing egress rules for Solr and Database access.
- Moves the common HTTP/HTTPS rules to a single "default" security group.
- Adds NTP to the "default" group