### PR TITLE
Pass ami_filter_name through to modules

### DIFF
--- a/catalog/main.tf
+++ b/catalog/main.tf
@@ -39,6 +39,7 @@ data "terraform_remote_state" "solr" {
 module "catalog" {
   source = "../modules/catalog"
 
+  ami_filter_name          = "${var.ami_filter_name}"
   bastion_host             = "${data.terraform_remote_state.jumpbox.jumpbox_dns}"
   database_subnet_group    = "${data.terraform_remote_state.vpc.database_subnet_group}"
   db_password              = "${var.db_password}"

--- a/inventory/main.tf
+++ b/inventory/main.tf
@@ -39,6 +39,7 @@ data "terraform_remote_state" "solr" {
 module "inventory" {
   source = "../modules/inventory"
 
+  ami_filter_name       = "${var.ami_filter_name}"
   bastion_host          = "${data.terraform_remote_state.jumpbox.jumpbox_dns}"
   database_subnet_group = "${data.terraform_remote_state.vpc.database_subnet_group}"
   db_password           = "${var.db_password}"


### PR DESCRIPTION
We're specifying trusty in datagov-infrastructure-live, but bionic AMI's are still getting selected. Make sure to pass the variable through.