### PR TITLE
[inventory] add web_instance_type variable

### DIFF
--- a/inventory/main.tf
+++ b/inventory/main.tf
@@ -51,6 +51,7 @@ module "inventory" {
   subnets_public        = "${data.terraform_remote_state.vpc.public_subnets}"
   vpc_id                = "${data.terraform_remote_state.vpc.vpc_id}"
   web_instance_count    = "${var.web_instance_count}"
+  web_instance_type     = "${var.web_instance_type}"
 
   security_groups = [
     "${data.terraform_remote_state.jumpbox.security_group_id}",

--- a/inventory/variables.tf
+++ b/inventory/variables.tf
@@ -21,3 +21,8 @@ variable "web_instance_count" {
   description = "Number of web instances to create."
   default     = 1
 }
+
+variable "web_instance_type" {
+  description = "Instance type to use for web."
+  default     = "t3.small"
+}

--- a/modules/inventory/main.tf
+++ b/modules/inventory/main.tf
@@ -40,6 +40,7 @@ module "web" {
   dns_zone_private = "${var.dns_zone_private}"
   env              = "${var.env}"
   instance_count   = "${var.web_instance_count}"
+  instance_type    = "${var.web_instance_type}"
   key_name         = "${var.key_name}"
   name             = "inventory"
   private_subnets  = "${var.subnets_private}"

--- a/modules/inventory/variables.tf
+++ b/modules/inventory/variables.tf
@@ -54,3 +54,8 @@ variable "web_instance_count" {
   description = "Number of web instances to create."
   default     = 1
 }
+
+variable "web_instance_type" {
+  description = "Instance type to use for web."
+  default     = "t3.small"
+}


### PR DESCRIPTION
Use t3.small, because CKAN dependency compilation requires quite a few
resources.