### PR TITLE
[jenkins] security groups for Jenkins SSH

### DIFF
--- a/modules/jenkins/main.tf
+++ b/modules/jenkins/main.tf
@@ -42,6 +42,14 @@ resource "aws_security_group" "default" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # Allow outbound SSH access for Ansible
+  egress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/8"]
+  }
+
   egress {
     from_port   = 80
     to_port     = 80
@@ -54,6 +62,19 @@ resource "aws_security_group" "default" {
     to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "jenkins_access" {
+  name        = "${var.env}-jenkins-access"
+  description = "Allows SSH access from jenkins."
+  vpc_id      = "${var.vpc_id}"
+
+  ingress {
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.default.id}"]
   }
 }
 


### PR DESCRIPTION
Part of https://github.com/GSA/datagov-deploy/issues/1337

This adds the security groups, but doesn't add the `jenkins_access` group to any of the hosts. It should be applied to all of them similar to `jumpbox_access`.