### PR TITLE
[solr] fix egress for consumers

### DIFF
--- a/modules/solr/main.tf
+++ b/modules/solr/main.tf
@@ -28,14 +28,6 @@ resource "aws_security_group" "default" {
   description = "Solr security group"
   vpc_id      = "${var.vpc_id}"
 
-  # Tomcat port
-  ingress {
-    from_port       = 8080
-    to_port         = 8080
-    protocol        = "tcp"
-    security_groups = ["${aws_security_group.solr_access.id}"]
-  }
-
   # Solr/Jetty port
   ingress {
     from_port       = 8983
@@ -56,13 +48,6 @@ resource "aws_security_group" "default" {
     to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port       = 8080
-    to_port         = 8080
-    protocol        = "tcp"
-    security_groups = ["${aws_security_group.solr_access.id}"]
   }
 
   egress {

--- a/modules/solr/main.tf
+++ b/modules/solr/main.tf
@@ -19,6 +19,10 @@ data "aws_ami" "ubuntu" {
   owners = ["099720109477"] # Canonical
 }
 
+data "aws_vpc" "default" {
+  id = "${var.vpc_id}"
+}
+
 resource "aws_security_group" "default" {
   name        = "solr-${var.env}-tf"
   description = "Solr security group"
@@ -73,6 +77,13 @@ resource "aws_security_group" "solr_access" {
   name        = "solr-access-${var.env}-tf"
   description = "Provides access to solr"
   vpc_id      = "${var.vpc_id}"
+
+  egress {
+    from_port       = 8983
+    to_port         = 8983
+    protocol        = "tcp"
+    cidr_blocks     = ["${data.aws_vpc.default.cidr_block}"]
+  }
 }
 
 module "default" {


### PR DESCRIPTION
Recently we added egress restrictions. That prevented ckan instances from talking to solr in sandbox. This adds explicit egress rules to the solr_access security group for consumers.