### PR TITLE
[db] add variable for db allocated storage

### DIFF
--- a/modules/catalog/main.tf
+++ b/modules/catalog/main.tf
@@ -26,6 +26,7 @@ module "db" {
   source = "../postgresdb"
 
   database_subnet_group = var.database_subnet_group
+  db_allocated_storage  = var.db_allocated_storage
   db_name               = "catalog_db"
   db_password           = var.db_password
   db_username           = "catalog_master"

--- a/modules/catalog/variables.tf
+++ b/modules/catalog/variables.tf
@@ -18,6 +18,11 @@ variable "database_security_group_ids" {
   default     = []
 }
 
+variable "db_allocated_storage" {
+  description = "Size in GB to allocate for database storage."
+  default     = "20"
+}
+
 variable "db_password" {
   description = "Master password for the catalog database server."
 }

--- a/modules/dashboard/main.tf
+++ b/modules/dashboard/main.tf
@@ -25,6 +25,7 @@ module "db" {
   source = "../mysql"
 
   database_subnet_group = var.database_subnet_group
+  db_allocated_storage  = var.db_allocated_storage
   db_name               = "dashboard_db"
   db_password           = var.db_password
   db_username           = "dashboard_master"

--- a/modules/dashboard/variables.tf
+++ b/modules/dashboard/variables.tf
@@ -18,6 +18,11 @@ variable "database_security_group_ids" {
   default     = []
 }
 
+variable "db_allocated_storage" {
+  description = "Size in GB to allocate for database storage."
+  default     = "20"
+}
+
 variable "db_password" {
   description = "Master password for the dashboard database server."
 }

--- a/modules/db/vars.tf
+++ b/modules/db/vars.tf
@@ -3,7 +3,7 @@ variable "env" {
 }
 
 variable "db_allocated_storage" {
-  default = "10"
+  default = "20"
 }
 
 variable "db_storage_type" {

--- a/modules/inventory/main.tf
+++ b/modules/inventory/main.tf
@@ -22,6 +22,7 @@ data "aws_ami" "ubuntu" {
 module "db" {
   source = "../postgresdb"
 
+  db_allocated_storage  = var.db_allocated_storage
   db_name               = var.db_name
   db_password           = var.db_password
   database_subnet_group = var.database_subnet_group

--- a/modules/inventory/variables.tf
+++ b/modules/inventory/variables.tf
@@ -23,6 +23,11 @@ variable "database_security_group_ids" {
   default     = []
 }
 
+variable "db_allocated_storage" {
+  description = "Size in GB to allocate for database storage."
+  default     = "20"
+}
+
 variable "db_name" {
   description = "Database name for inventory database server."
   default     = "inventory_db"

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -9,6 +9,7 @@ module "database" {
 
   database_port          = 3306
   database_subnet_group  = var.database_subnet_group
+  db_allocated_storage   = var.db_allocated_storage
   db_instance_class      = var.db_instance_class
   db_name                = var.db_name
   db_password            = var.db_password

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -2,6 +2,11 @@ variable "env" {
   description = "Name of the environment."
 }
 
+variable "db_allocated_storage" {
+  description = "Size in GB to allocate for database storage."
+  default     = "20"
+}
+
 variable "db_instance_class" {
   default = "db.t2.micro"
 }

--- a/modules/postgresdb/main.tf
+++ b/modules/postgresdb/main.tf
@@ -9,6 +9,7 @@ module "database" {
 
   database_port          = 5432
   database_subnet_group  = var.database_subnet_group
+  db_allocated_storage   = var.db_allocated_storage
   db_instance_class      = var.db_instance_class
   db_name                = var.db_name
   db_password            = var.db_password

--- a/modules/postgresdb/variables.tf
+++ b/modules/postgresdb/variables.tf
@@ -2,6 +2,11 @@ variable "env" {
   description = "Name of the environment."
 }
 
+variable "db_allocated_storage" {
+  description = "Size in GB to allocate for database storage."
+  default     = "20"
+}
+
 variable "db_instance_class" {
   default = "db.t2.micro"
 }

--- a/modules/wordpress/main.tf
+++ b/modules/wordpress/main.tf
@@ -29,6 +29,7 @@ module "db" {
   db_password           = var.db_password
   database_subnet_group = var.database_subnet_group
   db_username           = "wordpress_master"
+  db_allocated_storage  = var.db_allocated_storage
   env                   = var.env
   security_group_ids    = var.database_security_group_ids
   vpc_id                = var.vpc_id

--- a/modules/wordpress/variables.tf
+++ b/modules/wordpress/variables.tf
@@ -18,6 +18,11 @@ variable "database_security_group_ids" {
   default     = []
 }
 
+variable "db_allocated_storage" {
+  description = "Size in GB to allocate for database storage."
+  default     = "20"
+}
+
 variable "db_password" {
   description = "Master password for the wordpress database server."
 }


### PR DESCRIPTION
Seeing issues modifiying the catalog database because the storage is full. Bump
default to 20GB, givent this is a mostly empty database, trying to find a low
but reasonable size to prevent this from happening to other apps.

I added the variable so if it happens again, we can easily bump the size per
app without having to update modules.