### PR TITLE
[catalog] ensure unique harvester names

### DIFF
--- a/modules/catalog/main.tf
+++ b/modules/catalog/main.tf
@@ -66,7 +66,7 @@ module "web" {
 }
 
 resource "aws_security_group" "harvester" {
-  name        = "${var.env}-catalog-harvester-tf"
+  name        = "${var.env}-${var.harvester_instance_name}-tf"
   description = "Catalog harvester security group"
   vpc_id      = var.vpc_id
 
@@ -102,7 +102,7 @@ module "harvester" {
   dns_zone             = var.dns_zone_private
   env                  = var.env
   instance_count       = var.harvester_instance_count
-  instance_name_format = "catalog-harvester%dtf"
+  instance_name_format = "${var.harvester_instance_name}%dtf"
   instance_type        = var.harvester_instance_type
   key_name             = var.key_name
   subnets              = var.subnets_private

--- a/modules/catalog/variables.tf
+++ b/modules/catalog/variables.tf
@@ -60,6 +60,11 @@ variable "harvester_instance_count" {
   default     = 1
 }
 
+variable "harvester_instance_name" {
+  description = "The name of the harvester instance."
+  default     = "catalog-harvester"
+}
+
 variable "harvester_instance_type" {
   description = "Instance type to use for harvesters."
   default     = "t3.small"


### PR DESCRIPTION
Running into an error where the security group name for harvester is not unique. https://circleci.com/gh/GSA/datagov-infrastructure-live/1086