### PR TITLE
[redis] include subnets for proper VPC access

### DIFF
--- a/modules/catalog/main.tf
+++ b/modules/catalog/main.tf
@@ -22,6 +22,17 @@ data "aws_ami" "ubuntu" {
   owners = ["099720109477"] # Canonical
 }
 
+resource "aws_security_group" "web" {
+  name        = "${var.web_instance_name}-${var.env}"
+  description = "Security group for ${var.web_instance_name} web instance in ${var.env}"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    env  = var.env
+    name = var.web_instance_name
+  }
+}
+
 module "db" {
   source = "../postgresdb"
 
@@ -50,7 +61,7 @@ module "web" {
   name             = var.web_instance_name
   private_subnets  = var.subnets_private
   public_subnets   = var.subnets_public
-  security_groups  = concat(var.security_groups, [module.db.security_group, module.redis.security_group])
+  security_groups  = concat(var.security_groups, [module.db.security_group])
   vpc_id           = var.vpc_id
 
   lb_target_groups = [
@@ -112,7 +123,6 @@ module "harvester" {
     var.security_groups,
     [
       module.db.security_group,
-      module.redis.security_group,
       aws_security_group.harvester.id,
     ],
   )
@@ -121,9 +131,10 @@ module "harvester" {
 module "redis" {
   source = "../redis"
 
-  env       = var.env
-  name      = var.web_instance_name
-  node_type = var.redis_node_type
-  subnets   = var.subnets_private
-  vpc_id    = var.vpc_id
+  allow_security_groups = [aws_security_group.web.id, aws_security_group.harvester.id]
+  env                   = var.env
+  name                  = var.web_instance_name
+  node_type             = var.redis_node_type
+  subnets               = var.subnets_private
+  vpc_id                = var.vpc_id
 }

--- a/modules/catalog/main.tf
+++ b/modules/catalog/main.tf
@@ -121,8 +121,9 @@ module "harvester" {
 module "redis" {
   source = "../redis"
 
-  env = var.env
-  name = var.web_instance_name
+  env       = var.env
+  name      = var.web_instance_name
   node_type = var.redis_node_type
-  vpc_id = var.vpc_id
+  subnets   = var.subnets_private
+  vpc_id    = var.vpc_id
 }

--- a/modules/catalog/outputs.tf
+++ b/modules/catalog/outputs.tf
@@ -19,3 +19,6 @@ output "dns" {
   value = module.web.web_lb_dns
 }
 
+output "redis_cache_nodes" {
+  value = module.redis.cache_nodes
+}

--- a/modules/inventory/main.tf
+++ b/modules/inventory/main.tf
@@ -64,8 +64,9 @@ module "web" {
 module "redis" {
   source = "../redis"
 
-  env = var.env
-  name = var.web_instance_name
+  env       = var.env
+  name      = var.web_instance_name
   node_type = var.redis_node_type
-  vpc_id = var.vpc_id
+  subnets   = var.subnets_private
+  vpc_id    = var.vpc_id
 }

--- a/modules/inventory/main.tf
+++ b/modules/inventory/main.tf
@@ -19,6 +19,17 @@ data "aws_ami" "ubuntu" {
   owners = ["099720109477"] # Canonical
 }
 
+resource "aws_security_group" "inventory" {
+  name        = "${var.web_instance_name}-${var.env}"
+  description = "Security group for ${var.web_instance_name} web instance in ${var.env}"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    env  = var.env
+    name = var.web_instance_name
+  }
+}
+
 module "db" {
   source = "../postgresdb"
 
@@ -49,7 +60,7 @@ module "web" {
   public_subnets   = var.subnets_public
   vpc_id           = var.vpc_id
 
-  security_groups = concat(var.security_groups, [module.db.security_group, module.redis.security_group])
+  security_groups = concat(var.security_groups, [module.db.security_group])
 
   lb_target_groups = [
     {
@@ -64,9 +75,10 @@ module "web" {
 module "redis" {
   source = "../redis"
 
-  env       = var.env
-  name      = var.web_instance_name
-  node_type = var.redis_node_type
-  subnets   = var.subnets_private
-  vpc_id    = var.vpc_id
+  allow_security_groups = aws_security_group.inventory.id
+  env                   = var.env
+  name                  = var.web_instance_name
+  node_type             = var.redis_node_type
+  subnets               = var.subnets_private
+  vpc_id                = var.vpc_id
 }

--- a/modules/inventory/outputs.tf
+++ b/modules/inventory/outputs.tf
@@ -19,3 +19,6 @@ output "dns" {
   value = module.web.web_lb_dns
 }
 
+output "redis_cache_nodes" {
+  value = module.redis.cache_nodes
+}

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -36,6 +36,11 @@ resource "aws_security_group" "redis" {
   }
 }
 
+resource "aws_elasticache_subnet_group" "redis" {
+  name       = "${var.name}-${var.env}"
+  subnet_ids = var.subnets
+}
+
 resource "aws_elasticache_cluster" "redis" {
   cluster_id           = "${var.name}-${var.env}"
   engine               = "redis"
@@ -45,6 +50,7 @@ resource "aws_elasticache_cluster" "redis" {
   parameter_group_name = "default.redis5.0"
   port                 = var.port
   security_group_ids   = [aws_security_group.redis.id]
+  subnet_group_name    = aws_elasticache_subnet_group.redis.name
 
   tags = {
     env  = var.env

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -1,23 +1,5 @@
 provider "aws" {}
 
-resource "aws_security_group" "redis_access" {
-  name        = "${var.name}-redis-access-${var.env}"
-  description = "Security group to assign for Redis access."
-  vpc_id      = var.vpc_id
-
-  egress {
-    from_port   = var.port
-    to_port     = var.port
-    protocol    = "tcp"
-    cidr_blocks = ["10.0.0.0/8"]
-  }
-
-  tags = {
-    env  = var.env
-    name = var.name
-  }
-}
-
 resource "aws_security_group" "redis" {
   name        = "${var.name}-redis-${var.env}"
   description = "Security group for Redis"
@@ -27,7 +9,7 @@ resource "aws_security_group" "redis" {
     from_port       = var.port
     to_port         = var.port
     protocol        = "tcp"
-    security_groups = [aws_security_group.redis_access.id]
+    security_groups = var.allow_security_groups
   }
 
   tags = {

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -1,3 +1,3 @@
-output "security_group" {
-  value = aws_security_group.redis_access.id
+output "cache_nodes" {
+  value = aws_elasticache_cluster.redis.cache_nodes
 }

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -1,3 +1,8 @@
+variable "allow_security_groups" {
+  type        = list(string)
+  description = "List of security group Ids allowed to access redis"
+}
+
 variable "env" {
   type        = string
   description = "Name of the environment for generating Ids and unique names for Redis and associated resources."

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -18,6 +18,11 @@ variable "port" {
   default     = 6379
 }
 
+variable "subnets" {
+  description = "List of subnets to associate with the elasticache cluster."
+  type        = list(string)
+}
+
 variable "vpc_id" {
   description = "Id of the VPC where Redis should be provisioned."
 }


### PR DESCRIPTION
Didn't read the docs thoroughly and ended up with a mix of EC2 classic
resources instead of VPC.

Also refactors the security groups to avoid hitting the 5 security group limit on harvester.