### PR TITLE
Refactor Ansible/SSH security groups

### DIFF
--- a/modules/jenkins/main.tf
+++ b/modules/jenkins/main.tf
@@ -53,32 +53,21 @@ resource "aws_security_group" "default" {
     cidr_blocks = ["10.0.0.0/8"]
   }
 
-  egress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+  tags = {
+    env            = var.env
   }
 }
 
-resource "aws_security_group" "jenkins_access" {
-  name        = "${var.env}-jenkins-access"
-  description = "Allows SSH access from jenkins."
-  vpc_id      = var.vpc_id
+# Allow Ansible (SSH) access in the "default" vpc-wide security group
+resource "aws_security_group_rule" "ansible" {
+  description = "Allow Ansible access from Jenkins to VPC resources."
 
-  ingress {
-    from_port       = 22
-    to_port         = 22
-    protocol        = "tcp"
-    security_groups = [aws_security_group.default.id]
-  }
+  type = "ingress"
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+  security_group_id = var.default_security_group_id
+  source_security_group_id = aws_security_group.default.id
 }
 
 resource "aws_route53_record" "public" {

--- a/modules/jenkins/variables.tf
+++ b/modules/jenkins/variables.tf
@@ -18,6 +18,11 @@ variable "bastion_host" {
   default     = "" # unset
 }
 
+variable "default_security_group_id" {
+  type = string
+  description = "The \"default\" or vpc-wide security group to modify for Ansible access."
+}
+
 variable "dns_zone_private" {
   description = "The private DNS zone to create the host record in."
 }

--- a/modules/jumpbox/main.tf
+++ b/modules/jumpbox/main.tf
@@ -49,19 +49,22 @@ resource "aws_security_group" "default" {
     protocol    = "tcp"
     cidr_blocks = ["10.0.0.0/8"]
   }
+
+  tags = {
+    env            = var.env
+  }
 }
 
-resource "aws_security_group" "jumpbox_access" {
-  name        = "${var.env}-jumpbox-access-sg-tf"
-  description = "Allows SSH access from jumpbox."
-  vpc_id      = var.vpc_id
+# Allow Ansible (SSH) access in the "default" vpc-wide security group
+resource "aws_security_group_rule" "ansible" {
+  description = "Allow Ansible access from the Jumpbox to VPC resources."
 
-  ingress {
-    from_port       = 22
-    to_port         = 22
-    protocol        = "tcp"
-    security_groups = [aws_security_group.default.id]
-  }
+  type = "ingress"
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+  security_group_id = var.default_security_group_id
+  source_security_group_id = aws_security_group.default.id
 }
 
 resource "aws_iam_role" "jumpbox" {

--- a/modules/jumpbox/outputs.tf
+++ b/modules/jumpbox/outputs.tf
@@ -1,8 +1,3 @@
-output "security_group_id" {
-  value = aws_security_group.jumpbox_access.id
-}
-
 output "jumpbox_dns" {
   value = aws_route53_record.public.fqdn
 }
-

--- a/modules/jumpbox/variables.tf
+++ b/modules/jumpbox/variables.tf
@@ -8,6 +8,11 @@ variable "ansible_group" {
   default     = "jumpbox,v2"
 }
 
+variable "default_security_group_id" {
+  type = string
+  description = "The \"default\" or vpc-wide security group to modify for Ansible access."
+}
+
 variable "dns_zone_public" {
   description = "The name of the public DNS zone to use for creating a public DNS record."
 }


### PR DESCRIPTION
https://github.com/GSA/datagov-ckan-multi/issues/287

Instead of having a special SG that must be applied to all instances, modify the
"default" vpc-wide security group to allow for this access.

This fixes Jenkins jobs failing with Ansible timeouts (because security groups
are blocking SSH access).