### PR TITLE
[redis] add auth_token

### DIFF
--- a/modules/catalog/main.tf
+++ b/modules/catalog/main.tf
@@ -132,6 +132,7 @@ module "redis" {
   source = "../redis"
 
   allow_security_groups = [aws_security_group.web.id, aws_security_group.harvester.id]
+  auth_token            = var.redis_auth_token
   enable                = var.enable_redis
   env                   = var.env
   name                  = var.web_instance_name

--- a/modules/catalog/variables.tf
+++ b/modules/catalog/variables.tf
@@ -3,6 +3,17 @@ variable "ami_filter_name" {
   default     = "ubuntu/images/*ubuntu-bionic-18.04-amd64-server-*"
 }
 
+variable "redis_auth_token" {
+  type        = string
+  description = "The auth token (password) to configure for Redis."
+
+  # TODO enforce auth_token only when enable_redis is true.
+  # Since redis is optional, we have to set a default for auth_token. I think
+  # AWS will reject an empty auth_token, so we're safe from accidentally setting
+  # an empty password.
+  default     = ""
+}
+
 variable "bastion_host" {
   description = "Host/ip for the jumpbox/bastion host to connect to for provisioning."
   default     = "" # unset

--- a/modules/inventory/main.tf
+++ b/modules/inventory/main.tf
@@ -84,6 +84,7 @@ module "redis" {
   source = "../redis"
 
   allow_security_groups = [aws_security_group.inventory.id]
+  auth_token            = var.redis_auth_token
   enable                = var.enable_redis
   env                   = var.env
   name                  = var.web_instance_name

--- a/modules/inventory/variables.tf
+++ b/modules/inventory/variables.tf
@@ -8,6 +8,17 @@ variable "ansible_group" {
   default     = "inventory_web,v1"
 }
 
+variable "redis_auth_token" {
+  type        = string
+  description = "The auth token (password) to configure for Redis."
+
+  # TODO enforce auth_token only when enable_redis is true.
+  # Since redis is optional, we have to set a default for auth_token. I think
+  # AWS will reject an empty auth_token, so we're safe from accidentally setting
+  # an empty password.
+  default     = ""
+}
+
 variable "bastion_host" {
   description = "Host/ip for the jumpbox/bastion host to connect to for provisioning."
   default     = "" # unset

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -27,18 +27,22 @@ resource "aws_elasticache_subnet_group" "redis" {
   subnet_ids = var.subnets
 }
 
-resource "aws_elasticache_cluster" "redis" {
+resource "aws_elasticache_replication_group" "redis" {
   count = var.enable ? 1 : 0
 
-  cluster_id           = "${var.name}-${var.env}"
-  engine               = "redis"
-  engine_version       = "5.0.6"
-  node_type            = var.node_type
-  num_cache_nodes      = 1
-  parameter_group_name = "default.redis5.0"
-  port                 = var.port
-  security_group_ids   = [aws_security_group.redis.*.id]
-  subnet_group_name    = aws_elasticache_subnet_group.redis[count.index].name
+  auth_token                    = var.auth_token
+  automatic_failover_enabled    = false
+  engine                        = "redis"
+  engine_version                = "5.0.6"
+  node_type                     = var.node_type
+  number_cache_clusters         = 1
+  parameter_group_name          = "default.redis5.0"
+  port                          = var.port
+  replication_group_description = "Redis replication group for ${var.env}-${var.name}"
+  replication_group_id          = "rep-${var.env}-${var.name}"
+  security_group_ids            = [aws_security_group.redis[count.index].id]
+  subnet_group_name             = aws_elasticache_subnet_group.redis[count.index].name
+  transit_encryption_enabled    = true
 
   tags = {
     env  = var.env

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -1,3 +1,3 @@
 output "cache_nodes" {
-  value = aws_elasticache_cluster.redis.*.cache_nodes
+  value = aws_elasticache_replication_group.redis.*.primary_endpoint_address
 }

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -3,6 +3,11 @@ variable "allow_security_groups" {
   description = "List of security group Ids allowed to access redis"
 }
 
+variable "auth_token" {
+  type        = string
+  description = "The auth token (password) to configure for Redis."
+}
+
 variable "enable" {
   type        = bool
   description = "When enabled, provision a Redis ElastiCache instance."


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/1536

Not sure why aws_elasticache_cluster does not support auth_token, so switching
to aws_replication_group in non-cluster mode which does.