### PR TITLE
[redis] add auth_token as output

### DIFF
--- a/modules/catalog/outputs.tf
+++ b/modules/catalog/outputs.tf
@@ -19,6 +19,11 @@ output "dns" {
   value = module.web.web_lb_dns
 }
 
+output "redis_auth_token" {
+  value     = module.redis.auth_token
+  sensitive = true
+}
+
 output "redis_cache_nodes" {
   value = module.redis.cache_nodes
 }

--- a/modules/catalog/variables.tf
+++ b/modules/catalog/variables.tf
@@ -11,7 +11,7 @@ variable "redis_auth_token" {
   # Since redis is optional, we have to set a default for auth_token. I think
   # AWS will reject an empty auth_token, so we're safe from accidentally setting
   # an empty password.
-  default     = ""
+  default = ""
 }
 
 variable "bastion_host" {

--- a/modules/inventory/outputs.tf
+++ b/modules/inventory/outputs.tf
@@ -19,6 +19,11 @@ output "dns" {
   value = module.web.web_lb_dns
 }
 
+output "redis_auth_token" {
+  value     = module.redis.auth_token
+  sensitive = true
+}
+
 output "redis_cache_nodes" {
   value = module.redis.cache_nodes
 }

--- a/modules/inventory/variables.tf
+++ b/modules/inventory/variables.tf
@@ -16,7 +16,7 @@ variable "redis_auth_token" {
   # Since redis is optional, we have to set a default for auth_token. I think
   # AWS will reject an empty auth_token, so we're safe from accidentally setting
   # an empty password.
-  default     = ""
+  default = ""
 }
 
 variable "bastion_host" {

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -1,3 +1,8 @@
+output "auth_token" {
+  value     = aws_elasticache_replication_group.redis.*.auth_token
+  sensitive = true
+}
+
 output "cache_nodes" {
   value = aws_elasticache_replication_group.redis.*.primary_endpoint_address
 }


### PR DESCRIPTION
Add outputs so we can easily fetch the auth_token for the Ansible inventory.