### PR TITLE
Add web instance to web security group

### DIFF
--- a/modules/catalog/main.tf
+++ b/modules/catalog/main.tf
@@ -71,7 +71,15 @@ module "web" {
   name             = var.web_instance_name
   private_subnets  = var.subnets_private
   public_subnets   = var.subnets_public
-  security_groups  = concat(var.security_groups, [module.db.security_group])
+
+  security_groups = concat(
+    var.security_groups,
+    [
+      module.db.security_group,
+      aws_security_group.web.id,
+    ]
+  )   
+
   vpc_id           = var.vpc_id
 
   lb_target_groups = [


### PR DESCRIPTION
So, I may have this completely wrong, but it looks like the catalog web instance is never actually attached to web security group.

If I am not wrong, this may fix that issue.
