### PR TITLE
Revert "no need for port 80 for fgdc2iso"

### DIFF
--- a/modules/catalog/main.tf
+++ b/modules/catalog/main.tf
@@ -159,6 +159,13 @@ resource "aws_security_group" "fgdc2iso" {
   vpc_id      = var.vpc_id
 
   ingress {
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.harvester.id]
+  }
+
+  ingress {
     from_port       = 443
     to_port         = 443
     protocol        = "tcp"


### PR DESCRIPTION
This reverts commit 3be1c9894d5238297eb37220d9d5a0a0c51b1773.

we decided to keep port 80 open.