### PR TITLE
update docs for inventory-next

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ Tests include light terraform syntax validation. Don't forget to run the tests.
 You might also want to standardize the syntax in your files.
 
     $ terraform fmt
+

--- a/modules/catalog/variables.tf
+++ b/modules/catalog/variables.tf
@@ -20,7 +20,7 @@ variable "database_security_group_ids" {
 
 variable "db_allocated_storage" {
   description = "Size in GB to allocate for database storage."
-  default     = "20"
+  default     = "30"
 }
 
 variable "db_name" {

--- a/modules/inventory/variables.tf
+++ b/modules/inventory/variables.tf
@@ -110,7 +110,7 @@ variable "web_instance_type" {
 }
 
 variable "web_instance_name" {
-  description = "The name of the web instance. ie inventory_2_8 or inventory"
+  description = "The name of the web instance. ie inventory-next or inventory"
   default     = "inventory"
 }
 


### PR DESCRIPTION
Update description to represent inventory-next instead of inventory-2-8 (deprecated).
Related to [#1678](https://github.com/GSA/datagov-deploy/issues/1678)