### PR TITLE
Add security group to inventory web

### DIFF
--- a/modules/inventory/main.tf
+++ b/modules/inventory/main.tf
@@ -87,7 +87,13 @@ module "web" {
   public_subnets       = var.subnets_public
   vpc_id               = var.vpc_id
 
-  security_groups = concat(var.security_groups, [module.db.security_group])
+  security_groups = concat(
+    var.security_groups, 
+    [
+      module.db.security_group, 
+      aws_security_group.inventory.id
+    ]
+  )
 
   lb_target_groups = [
     {

--- a/modules/inventory/main.tf
+++ b/modules/inventory/main.tf
@@ -91,7 +91,7 @@ module "web" {
     var.security_groups, 
     [
       module.db.security_group, 
-      aws_security_group.inventory.id
+      aws_security_group.inventory.id,
     ]
   )
 


### PR DESCRIPTION
This security group mimics the current catalog infrastructure and should allow inventory-web to connect to the created redis instance.